### PR TITLE
Update Tinkergraph.php

### DIFF
--- a/library/Exakat/Graph/Tinkergraph.php
+++ b/library/Exakat/Graph/Tinkergraph.php
@@ -244,7 +244,7 @@ class Tinkergraph extends Graph {
 
     public function getDefinitionSQL() {
         return <<<SQL
-SELECT DISTINCT CASE WHEN definitions.id IS NULL THEN definitions2.id - 1 ELSE definitions.id - 1 END AS definition, calls.id - 1 AS call
+SELECT DISTINCT CASE WHEN definitions.id IS NULL THEN definitions2.id ELSE definitions.id END AS definition, calls.id AS call
 FROM calls
 LEFT JOIN definitions 
     ON definitions.type       = calls.type       AND


### PR DESCRIPTION
bugfix. 
Tinkergraph Project Id starts from 1, but gsneo4j Project Id starts from 0.
So if use Tinkergraph as graph backend, "getDefinitionSQL" method should not "-1".